### PR TITLE
Changing URL (docker community slack)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ an existing issue. If possible, we recommend that you suggest a fix to the issue
 by creating a pull request.
 
 You can ask general questions and get community support through the [Docker
-Community Slack](http://dockr.ly/slack). Personalized support is available
+Community Slack](https://dockr.ly/comm-slack). Personalized support is available
 through the Docker Pro, Team, and Business subscriptions. See [Docker
 Pricing](https://www.docker.com/pricing) for details.
 


### PR DESCRIPTION
Docker Community Slack URL for joining the community accepts email address only with docker.com and jackmorton.com these domains. I got a link which works perfectly for other email addresses also.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
